### PR TITLE
Implement JWT login

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ O sistema implementa autenticação baseada em JWT com as seguintes característ
 
 ### Configurações de Segurança
 - Endpoints PUT em `/api/**` requerem autenticação
+- `POST /api/auth/login` é público para geração do token
 - Demais endpoints são públicos
 - Sessões stateless (sem estado)
 
@@ -134,6 +135,36 @@ O sistema implementa autenticação baseada em JWT com as seguintes característ
 - `PUT /api/vehicles/{id}` - Atualizar veículo (requer autenticação)
 - `DELETE /api/vehicles/{id}` - Excluir veículo
 
+### Autenticação (`/api/auth`)
+- `POST /api/auth/login` - Gerar token JWT
+
+### Exemplos de Requisição
+
+```bash
+# Login e obtenção do token
+curl -X POST http://localhost:3000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@email.com","password":"123"}'
+
+# Listar clientes
+curl http://localhost:3000/api/clients
+
+# Criar cliente (requer token)
+curl -X POST http://localhost:3000/api/clients \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <TOKEN>" \
+  -d '{"name":"Joao","document":"123","phone":"999","email":"joao@test.com"}'
+
+# Listar veículos
+curl http://localhost:3000/api/vehicles
+
+# Criar veículo (requer token)
+curl -X POST http://localhost:3000/api/vehicles \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <TOKEN>" \
+  -d '{"licensePlate":"ABC-1234","brand":"Fiat"}'
+```
+
 ## ⚙️ Configuração do Ambiente
 
 ### Pré-requisitos
@@ -143,11 +174,13 @@ O sistema implementa autenticação baseada em JWT com as seguintes característ
 
 ### Configuração do Banco de Dados
 
-O sistema está configurado para conectar com Oracle Database:
+Defina as variáveis de ambiente `DB_USERNAME` e `DB_PASSWORD` com as credenciais do Oracle.
 
 ```properties
 spring.datasource.url=jdbc:oracle:thin:@localhost:1521/FREEPDB1
 spring.datasource.driver-class-name=oracle.jdbc.OracleDriver
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 ```
 
 ### Configurações da Aplicação

--- a/src/main/java/com/gomech/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/gomech/configuration/SecurityConfiguration.java
@@ -11,6 +11,8 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -19,9 +21,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfiguration {
 
     private final SecurityFilter securityFilter;
+    private final com.gomech.repository.UserRepository userRepository;
 
-    public SecurityConfiguration(SecurityFilter securityFilter) {
+    public SecurityConfiguration(SecurityFilter securityFilter, com.gomech.repository.UserRepository userRepository) {
         this.securityFilter = securityFilter;
+        this.userRepository = userRepository;
     }
 
     @Bean
@@ -46,5 +50,11 @@ public class SecurityConfiguration {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return username -> userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
     }
 }

--- a/src/main/java/com/gomech/controller/AuthController.java
+++ b/src/main/java/com/gomech/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.gomech.controller;
+
+import com.gomech.dto.AuthenticationDTO;
+import com.gomech.dto.TokenDTO;
+import com.gomech.service.AuthService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+    @Autowired
+    private AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenDTO> login(@RequestBody AuthenticationDTO data) {
+        String token = authService.login(data.getEmail(), data.getPassword());
+        return ResponseEntity.ok(new TokenDTO(token));
+    }
+}

--- a/src/main/java/com/gomech/dto/AuthenticationDTO.java
+++ b/src/main/java/com/gomech/dto/AuthenticationDTO.java
@@ -1,0 +1,11 @@
+package com.gomech.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AuthenticationDTO {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/gomech/dto/TokenDTO.java
+++ b/src/main/java/com/gomech/dto/TokenDTO.java
@@ -1,0 +1,10 @@
+package com.gomech.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenDTO {
+    private String token;
+}

--- a/src/main/java/com/gomech/service/AuthService.java
+++ b/src/main/java/com/gomech/service/AuthService.java
@@ -1,0 +1,23 @@
+package com.gomech.service;
+
+import com.gomech.model.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+    @Autowired
+    private AuthenticationManager authenticationManager;
+    @Autowired
+    private TokenService tokenService;
+
+    public String login(String email, String password) {
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(email, password);
+        Authentication authentication = authenticationManager.authenticate(authToken);
+        User user = (User) authentication.getPrincipal();
+        return tokenService.generateToken(user);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,12 @@
 spring.application.name=Gomech
 server.port=3000
 spring.datasource.url=jdbc:oracle:thin:@localhost:1521/FREEPDB1
-spring.datasource.username=GOMECH
-spring.datasource.password=DBgomech3006
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=oracle.jdbc.OracleDriver
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
 spring.jpa.show-sql=true
+
+api.security.token.secret=CHANGEME_SECRET


### PR DESCRIPTION
## Summary
- add login DTOs
- add authentication service and controller
- wire user lookup into `SecurityConfiguration`
- expose POST `/api/auth/login` endpoint
- document auth login endpoint in README
- define `api.security.token.secret` property
- clarify how to use environment variables for DB credentials
- document example curl commands

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM - Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from `maven.oracle.com`)*

------
https://chatgpt.com/codex/tasks/task_e_6855cdc0a1bc8320ac7d4db7606d2579