### PR TITLE
Add user registration endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ O sistema implementa autenticação baseada em JWT com as seguintes característ
 
 ### Autenticação (`/api/auth`)
 - `POST /api/auth/login` - Gerar token JWT
+- `POST /api/auth/register` - Criar novo usuário
 
 ## ⚙️ Configuração do Ambiente
 

--- a/REQUESTS.md
+++ b/REQUESTS.md
@@ -45,6 +45,32 @@ Content-Type: application/json
 }
 ```
 
+### Criar Usuário
+
+**Endpoint:** `POST /api/auth/register`
+
+**Headers:**
+```
+Content-Type: application/json
+```
+
+**Corpo da Requisição:**
+```json
+{
+  "email": "admin@gomech.com",
+  "password": "123456",
+  "roleId": 1
+}
+```
+
+**Exemplo de Resposta (201 Created):**
+```json
+{
+  "id": 1,
+  "email": "admin@gomech.com"
+}
+```
+
 ## 👥 Clientes
 
 ### Criar Novo Cliente

--- a/src/main/java/com/gomech/controller/AuthController.java
+++ b/src/main/java/com/gomech/controller/AuthController.java
@@ -2,7 +2,11 @@ package com.gomech.controller;
 
 import com.gomech.dto.AuthenticationDTO;
 import com.gomech.dto.TokenDTO;
+import com.gomech.dto.RegisterDTO;
+import com.gomech.model.User;
 import com.gomech.service.AuthService;
+import com.gomech.service.UserService;
+import org.springframework.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,9 +20,18 @@ public class AuthController {
     @Autowired
     private AuthService authService;
 
+    @Autowired
+    private UserService userService;
+
     @PostMapping("/login")
     public ResponseEntity<TokenDTO> login(@RequestBody AuthenticationDTO data) {
         String token = authService.login(data.getEmail(), data.getPassword());
         return ResponseEntity.ok(new TokenDTO(token));
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<User> register(@RequestBody RegisterDTO dto) {
+        User user = userService.createUser(dto.getEmail(), dto.getPassword(), dto.getRoleId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(user);
     }
 }

--- a/src/main/java/com/gomech/dto/RegisterDTO.java
+++ b/src/main/java/com/gomech/dto/RegisterDTO.java
@@ -1,0 +1,12 @@
+package com.gomech.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RegisterDTO {
+    private String email;
+    private String password;
+    private Long roleId;
+}

--- a/src/main/java/com/gomech/repository/RoleRepository.java
+++ b/src/main/java/com/gomech/repository/RoleRepository.java
@@ -1,0 +1,12 @@
+package com.gomech.repository;
+
+import com.gomech.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByNome(String nome);
+}

--- a/src/main/java/com/gomech/service/UserService.java
+++ b/src/main/java/com/gomech/service/UserService.java
@@ -1,0 +1,32 @@
+package com.gomech.service;
+
+import com.gomech.model.Role;
+import com.gomech.model.User;
+import com.gomech.repository.RoleRepository;
+import com.gomech.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    public User createUser(String email, String password, Long roleId) {
+        Role role = roleRepository.findById(roleId)
+                .orElseThrow(() -> new RuntimeException("Role not found"));
+        User user = new User();
+        user.setEmail(email);
+        user.setPassword(passwordEncoder.encode(password));
+        user.setRole(role);
+        return userRepository.save(user);
+    }
+}


### PR DESCRIPTION
## Summary
- add DTO for user registration
- add RoleRepository and UserService
- expose new POST `/api/auth/register` endpoint
- document registration flow

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855f0168b60832091ec1b06ccf3e113